### PR TITLE
support for python 3.4 + travis build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,89 @@
-.hg*
-*.pyc
-*.egg-info
-*.swp
-\.coverage
-*~
-build
-dist
-htmlcov
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask instance folder
+instance/
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+language:
+  - python
+python:
+  - '2.7'
+before_install:
+  - pip install --upgrade setuptools
+
+cache:
+  apt: true
+  directories:
+    - $HOME/.cache/pip
+
+install:
+  - python setup.py dev
+
+script:
+  - python setup.py flake8
+  - python setup.py nosetests

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,6 @@ pyramid_whoauth
 
 An authentication policy for Pyramid that uses the repoze.who v2 API.
 
-    This is a fork of the original [Pyramid WhoAuth](https://github.com/mozilla-services/pyramid_whoauth).
-    Our motivation was to ensure that it can be run on Python 3.
 
 Overview
 ========

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@ pyramid_whoauth
 
 An authentication policy for Pyramid that uses the repoze.who v2 API.
 
+    This is a fork of the original [Pyramid WhoAuth](https://github.com/mozilla-services/pyramid_whoauth).
+    Our motivation was to ensure that it can be run on Python 3.
 
 Overview
 ========

--- a/pyramid_whoauth/__init__.py
+++ b/pyramid_whoauth/__init__.py
@@ -7,20 +7,19 @@ Pyramid authentication policy build on repoze.who.
 
 """
 
-__ver_major__ = 0
-__ver_minor__ = 1
-__ver_patch__ = 2
-__ver_sub__ = ""
-__ver_tuple__ = (__ver_major__, __ver_minor__, __ver_patch__, __ver_sub__)
-__version__ = "%d.%d.%d%s" % __ver_tuple__
-
-
 from repoze.who.api import IAPIFactory
 
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.tweens import EXCVIEW
 
 from pyramid_whoauth import utils, auth, views
+
+__ver_major__ = 0
+__ver_minor__ = 1
+__ver_patch__ = 2
+__ver_sub__ = ""
+__ver_tuple__ = (__ver_major__, __ver_minor__, __ver_patch__, __ver_sub__)
+__version__ = "%d.%d.%d%s" % __ver_tuple__
 
 
 def includeme(config):

--- a/pyramid_whoauth/__init__.py
+++ b/pyramid_whoauth/__init__.py
@@ -9,7 +9,7 @@ Pyramid authentication policy build on repoze.who.
 
 __ver_major__ = 0
 __ver_minor__ = 1
-__ver_patch__ = 2
+__ver_patch__ = 3
 __ver_sub__ = ""
 __ver_tuple__ = (__ver_major__, __ver_minor__, __ver_patch__, __ver_sub__)
 __version__ = "%d.%d.%d%s" % __ver_tuple__

--- a/pyramid_whoauth/auth.py
+++ b/pyramid_whoauth/auth.py
@@ -7,7 +7,7 @@ IAuthenticationPolicy implementation for pyramid_whoauth
 
 """
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from pyramid.interfaces import IAuthenticationPolicy
 from pyramid.security import Everyone, Authenticated
@@ -23,6 +23,7 @@ def _null_callback(userid, request):
     return ()
 
 
+@implementer(IAuthenticationPolicy)
 class WhoAuthenticationPolicy(object):
     """Pyramid authentication policy built on top of repoze.who.
 
@@ -31,8 +32,6 @@ class WhoAuthenticationPolicy(object):
     callback, and does a straightforward transformation between the repoze.who
     API methods and those of pyramid.
     """
-
-    implements(IAuthenticationPolicy)
 
     def __init__(self, api_factory=None, callback=None):
         if callback is None:

--- a/pyramid_whoauth/tests.py
+++ b/pyramid_whoauth/tests.py
@@ -76,13 +76,13 @@ def groupfinder(userid, request):
 
 
 GOOD_AUTHZ = {
-  "test": "Basic " + base64.b64encode("test:test"),
-  "test2": "Basic " + base64.b64encode("test2:test2")}
+    "test": "Basic " + base64.b64encode("test:test"),
+    "test2": "Basic " + base64.b64encode("test2:test2")}
 
 
 BAD_AUTHZ = {
-  "test": "Basic " + base64.b64encode("test:badpwd"),
-  "test2": "Basic " + base64.b64encode("test2:horseyhorseyneigh")}
+    "test": "Basic " + base64.b64encode("test:badpwd"),
+    "test2": "Basic " + base64.b64encode("test2:horseyhorseyneigh")}
 
 
 SETTINGS = {
@@ -95,8 +95,8 @@ SETTINGS = {
     "who.identifiers.plugins": "dummyid basicauth dummyredir",
     "who.authenticators.plugins": ["dummyauth"],
     "who.challengers.plugins": "basicauth",
-    "who.general.challenge_decider":
-            "repoze.who.classifiers:default_challenge_decider"}
+    "who.general.challenge_decider": "repoze.who.classifiers:default_challenge_decider"
+}
 
 
 def raise_forbidden(request):
@@ -267,6 +267,7 @@ class WhoAuthPolicyTests(unittest2.TestCase):
     def test_challenge_view_gets_invoked(self):
         app = self.config.make_wsgi_app()
         req = make_request(PATH_INFO="/forbidden")
+
         def start_response(status, headers):  # NOQA
             self.assertEquals(status, "401 Unauthorized")
             self.assertHeadersContain(headers, "WWW-Authenticate", "MyRealm")
@@ -277,6 +278,7 @@ class WhoAuthPolicyTests(unittest2.TestCase):
         del policy.api_factory.challengers[:]
         app = self.config.make_wsgi_app()
         req = make_request(PATH_INFO="/forbidden")
+
         def start_response(status, headers):  # NOQA
             self.assertEquals(status, "403 Forbidden")
         "".join(app(req.environ, start_response))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[aliases]
+dev = develop easy_install pyramid_whoauth[test]
+
+[nosetests]
+where=pyramid_whoauth
+match=^test
+nocapture=1
+cover-package=pyramid_whoauth
+with-coverage=1
+cover-erase=1
+cover-inclusive=1
+cover-tests=0
+
+[flake8]
+ignore=E501,E901,E902
+max-line-length=99

--- a/setup.py
+++ b/setup.py
@@ -12,21 +12,29 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
 
 requires = ['pyramid', 'repoze.who', 'unittest2']
 
+extras_require = {
+    'test': [
+        'flake8',
+        'nose',
+    ]
+}
+
 setup(name='pyramid_whoauth',
       version='0.1.2',
       description='pyramid_whoauth',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[
-        "Programming Language :: Python",
-        "Framework :: Pylons",
-        "Topic :: Internet :: WWW/HTTP",
-        ],
+          "Programming Language :: Python :: 2.7",
+          "Framework :: Pylons",
+          "Topic :: Internet :: WWW/HTTP",
+      ],
       author='Mozilla Services',
       author_email='services-dev@mozilla.org',
       url='https://github.com/mozilla-services/pyramid_whoauth',
       keywords='web pyramid pylons authentication',
       packages=find_packages(),
       include_package_data=True,
+      extras_require=extras_require,
       zip_safe=False,
       install_requires=requires,
       tests_require=requires,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 
 import os
+import sys
 from setuptools import setup, find_packages
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -11,6 +12,9 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
 requires = ['pyramid', 'repoze.who', 'unittest2']
+
+if sys.version_info[0] == 3:
+    requires[2] += "py3k"
 
 setup(name='pyramid_whoauth',
       version='0.1.2',

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,12 @@ extras_require = {
 
 
 setup(name='pyramid_whoauth',
-      version='0.1.2',
+      version='0.2.0',
       description='pyramid_whoauth',
       long_description=README + '\n\n' + CHANGES,
       classifiers=[
           "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
           "Framework :: Pylons",
           "Topic :: Internet :: WWW/HTTP",
       ],


### PR DESCRIPTION
This is a pull request to patch the `pyramid_whoauth` library to be python 3 compatible (specifically Python3.4).

As we required this library to be able to run on Python3.4, we thus required these code changes and hope anyone else looking for a similar solution can refer to this.

Also included some changes on setup.py and added a Travis yml file to run flake8 checks and unit tests.

Thanks to this original [pull request as a reference](https://github.com/mozilla-services/pyramid_whoauth/pull/1)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla-services/pyramid_whoauth/5)
<!-- Reviewable:end -->
